### PR TITLE
switch to synchronous job processing

### DIFF
--- a/app/controllers/conversations_controller.rb
+++ b/app/controllers/conversations_controller.rb
@@ -25,7 +25,9 @@ before_action :set_request_params, only: [:create]
   end
 
   def create
-    Sidekiq::Client.enqueue(RecordConversation, @request_params["data"]["item"]["id"])
+    # To record this asynchronously:
+    # Sidekiq::Client.enqueue(RecordConversation, @request_params["data"]["item"]["id"])
+    RecordConversation.new.perform(@request_params["data"]["item"]["id"])
     head :ok
   end
 


### PR DESCRIPTION
It's not strictly necessary to process in a job queue, as updating a single row is not noticeably slower than creating a sidekiq job, and this saves the overhead of running a separate process. We do lose the benefit of a "free" morgue to see stacktraces, but we should be confident that this is now working reasonably reliably.