### PR TITLE
perform the sync synchronously

### DIFF
--- a/lib/tasks/scheduler.rake
+++ b/lib/tasks/scheduler.rake
@@ -8,7 +8,7 @@ namespace :scheduler do
   task :sync_intercom_tag_data => :environment do
     if Date.today.wday == 1
       most_recent_id = ConversationData.most_recent.id
-      Sidekiq::Client.enqueue(SyncIntercomTagData, most_recent_id)
+      SyncIntercomTagData.perform(most_recent_id)
       new_most_recent = ConversationData.create
     end
   end


### PR DESCRIPTION
Note that if `SyncIntercomTagData#perform` raises an exception, we will have to manually run the task, otherwise conversation ids will continue being added to the previous week's record.